### PR TITLE
Option to create custom-hexagon shape

### DIFF
--- a/polygon.go
+++ b/polygon.go
@@ -30,6 +30,7 @@ type CustomPolygon struct {
 	RelTo    string   `json:"rel_to"`
 	RelAbs   string   `json:"-"`
 	Width    float64  `json:"width"`
+	Angle    float64  `json:"angle"`
 }
 
 // Sets the path to the absolute positioning of the Path relative to an origin Point 'r'.
@@ -179,6 +180,13 @@ func (k *KAD) FinalizePolygons() {
 						for _, path := range paths {
 							for _, pt := range path {
 								polygons = append(polygons, RoundRectanglePolygon(pt.X, pt.Y, cp.Width, cp.Height, cp.Radius, 20))
+							}
+						}
+						break
+					case "custom-hexagon":
+						for _, path := range paths {
+							for _, pt := range path {
+								polygons = append(polygons, HexagonPolygon(pt.X, pt.Y, cp.Radius, cp.Angle))
 							}
 						}
 						break
@@ -394,6 +402,26 @@ func CirclePolygon(cx, cy, r float64, s int) Path {
 	// draw the circle
 	pts := make(Path, 0)
 	circle(cx, cy-r, r, s, &pts)
+	return pts
+}
+
+// create a regular hexagon with vertices at distance 'r' from the center.
+// set 'a' (angle in degrees) to rotate the hexagon around its center.
+func HexagonPolygon(cx, cy, r float64, a float64) Path {
+	// make a hexagon
+	hexagon := func(x, y, r float64, a float64, ps *Path) {
+		p := &Point{x, y}
+		*ps = append(*ps, *p)
+		for j := 0.0; j <= 6.0; j++ {
+			aj := a + 60.0*j
+			p.X = x + r * math.Cos(radians(aj))
+			p.Y = y + r * math.Sin(radians(aj))
+			*ps = append(*ps, *p)
+		}
+	}
+	// draw the hexagon
+	pts := make(Path, 0)
+	hexagon(cx, cy, r, a, &pts)
 	return pts
 }
 


### PR DESCRIPTION
I chose to add an hexagon option to custom shapes. It is already possible to create hexagons using the custom polygon feature, but it's easier to do and script using a predefined shape.

A good alternative to this pull request would be to modify the creation of circles, allowing users to chose the number of lines used for the approximation. This creates an option to draw any regular polygon. Let me know if you find this more interesting.